### PR TITLE
Manually fix dependencies for debian wheezy upgrade

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,7 +12,7 @@ class rsyslogv8::install {
     package { $rsyslogv8::relp_package_name:
       ensure  => $rsyslogv8::package_status,
       notify  => Class['rsyslogv8::service'],
-      require => Class['rsyslogv8::repository'],
+      require => [Class['rsyslogv8::repository'], Package[$rsyslogv8::rsyslog_package_name]],
     }
   }
 
@@ -20,7 +20,7 @@ class rsyslogv8::install {
     package { $rsyslogv8::gnutls_package_name:
       ensure  => $rsyslogv8::package_status,
       notify  => Class['rsyslogv8::service'],
-      require => Class['rsyslogv8::repository'],
+      require => [Class['rsyslogv8::repository'], Package[$rsyslogv8::rsyslog_package_name]],
     }
   }
 
@@ -28,7 +28,7 @@ class rsyslogv8::install {
     package { $rsyslogv8::kafka_package_name:
       ensure  => $rsyslogv8::package_status,
       notify  => Class['rsyslogv8::service'],
-      require => Class['rsyslogv8::repository'],
+      require => [Class['rsyslogv8::repository'], Package[$rsyslogv8::rsyslog_package_name]],
     }
   }
 


### PR DESCRIPTION
upgrades from 7.x to 8.22 on wheezy tried to install rsyslog-gnutls or relp packages before the main rsyslog package, leading to unresolved dependencies ("rsyslog-gnutls requires 8.22 but 7.x is installed...").

These puppet dependencies seems to solve this.